### PR TITLE
Add Random User API data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df.select("id", "title", "author").show()
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
+| `randomuser` | Batch | — | Fake user profiles for testing | built-in | [→](examples/randomuser.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 
 📚 **[See detailed examples →](docs/data-sources-guide.md)** · **[Copy-pastable examples →](examples/README.md)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
+| randomuser | Batch | — | [randomuser.md](randomuser.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 
 These examples are designed for humans and AI agents to quickly generate working code.

--- a/examples/randomuser.md
+++ b/examples/randomuser.md
@@ -1,0 +1,53 @@
+# Random User Data Source Example
+
+Read fake user profiles from the Random User API. No credentials required. Useful for testing and demos.
+
+## Setup Credentials
+
+None required.
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import RandomUserDataSource
+
+spark = SparkSession.builder.appName("randomuser-example").getOrCreate()
+spark.dataSource.register(RandomUserDataSource)
+```
+
+### Step 2: Read Default (10 Users)
+
+```python
+df = spark.read.format("randomuser").load()
+df.select("first_name", "last_name", "email", "country").show(10, truncate=False)
+```
+
+### Step 3: Read More Users
+
+```python
+df = spark.read.format("randomuser").option("results", "100").load()
+df.count()
+```
+
+### Step 4: Filter and Aggregate
+
+```python
+df = spark.read.format("randomuser").option("results", "50").load()
+by_country = df.groupBy("country").count().orderBy("count", ascending=False)
+by_country.show(10, truncate=False)
+```
+
+### Example Output
+
+```
++-------------+-----+
+|country      |count|
++-------------+-----+
+|United States|   12|
+|United Kingdom|   8|
+|France       |   6|
++-------------+-----+
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .randomuser import RandomUserDataSource

--- a/pyspark_datasources/randomuser.py
+++ b/pyspark_datasources/randomuser.py
@@ -1,0 +1,82 @@
+"""Random User API data source - generates fake user profiles for testing."""
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+
+class RandomUserDataSource(DataSource):
+    """
+    A DataSource for reading fake user profiles from the Random User API.
+
+    No API key required. Useful for testing and generating sample data.
+
+    Name: `randomuser`
+
+    Schema: `gender string, first_name string, last_name string, email string,
+    city string, country string, phone string, dob string, nat string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import RandomUserDataSource
+    >>> spark.dataSource.register(RandomUserDataSource)
+
+    Load 10 random users (default).
+
+    >>> spark.read.format("randomuser").load().show()
+
+    Load 100 users.
+
+    >>> spark.read.format("randomuser").option("results", "100").load().show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "randomuser"
+
+    def schema(self):
+        return (
+            "gender string, first_name string, last_name string, email string, "
+            "city string, country string, phone string, dob string, nat string"
+        )
+
+    def reader(self, schema):
+        return RandomUserReader(self.options)
+
+
+class RandomUserReader(DataSourceReader):
+    def __init__(self, options):
+        self.options = options
+        self.results = int(self.options.get("results", "10"))
+        self.results = min(max(self.results, 1), 5000)  # API limit 1-5000
+
+    def read(self, partition):
+        try:
+            response = requests.get(
+                "https://randomuser.me/api/",
+                params={"results": self.results},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            results = data.get("results", [])
+
+            for u in results:
+                name = u.get("name", {})
+                loc = u.get("location", {})
+                dob = u.get("dob", {})
+                yield Row(
+                    gender=u.get("gender", ""),
+                    first_name=name.get("first", ""),
+                    last_name=name.get("last", ""),
+                    email=u.get("email", ""),
+                    city=loc.get("city", ""),
+                    country=loc.get("country", ""),
+                    phone=u.get("phone", ""),
+                    dob=dob.get("date", ""),
+                    nat=u.get("nat", ""),
+                )
+        except requests.RequestException:
+            return iter([])

--- a/tests/test_randomuser.py
+++ b/tests/test_randomuser.py
@@ -1,0 +1,33 @@
+"""Tests for RandomUserDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import RandomUserDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_randomuser_datasource_registration(spark):
+    """Test that RandomUserDataSource can be registered."""
+    spark.dataSource.register(RandomUserDataSource)
+    assert RandomUserDataSource.name() == "randomuser"
+
+
+def test_randomuser_read(spark):
+    """Test reading random users (integration test - uses real API)."""
+    spark.dataSource.register(RandomUserDataSource)
+    try:
+        df = spark.read.format("randomuser").option("results", "5").load()
+        rows = df.collect()
+        assert len(rows) <= 5
+        assert len(rows) > 0
+        assert "first_name" in df.columns
+        assert "email" in df.columns
+    except Exception as exc:
+        if "timeout" in str(exc).lower() or "connection" in str(exc).lower():
+            pytest.skip("Network unavailable")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading fake user profiles from the [Random User API](https://randomuser.me/).

## Features
- **No API key required** - free public API
- Load 10 users (default) with `spark.read.format("randomuser").load()`
- Customize count with `option("results", "100")` (1-5000)
- Schema: gender, first_name, last_name, email, city, country, phone, dob, nat

## Checklist
- [x] Implementation
- [x] Tests
- [x] Documentation

Made with [Cursor](https://cursor.com)