### PR TITLE
Add OpenFDA data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df.select("id", "title", "author").show()
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
+| `openfda` | Batch | — | FDA drug/food/device data | built-in | [→](examples/openfda.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 
 📚 **[See detailed examples →](docs/data-sources-guide.md)** · **[Copy-pastable examples →](examples/README.md)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
+| openfda | Batch | — | [openfda.md](openfda.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 
 These examples are designed for humans and AI agents to quickly generate working code.

--- a/examples/openfda.md
+++ b/examples/openfda.md
@@ -1,0 +1,41 @@
+# OpenFDA Data Source Example
+
+Read drug labels, food recalls, and device events from the FDA's OpenFDA API. No API key required for reasonable usage.
+
+## Setup Credentials
+
+None required (optional API key for higher rate limits).
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import OpenFdaDataSource
+
+spark = SparkSession.builder.appName("openfda-example").getOrCreate()
+spark.dataSource.register(OpenFdaDataSource)
+```
+
+### Step 2: Read Drug Labels (Default)
+
+```python
+df = spark.read.format("openfda").option("limit", "50").load()
+df.select("brand_name", "generic_name", "manufacturer_name", "purpose").show(10, truncate=30)
+```
+
+### Step 3: Read Food Recalls
+
+```python
+df = spark.read.format("openfda").option("endpoint", "food/event").option("limit", "20").load()
+df.show(5, truncate=30)
+```
+
+### Step 4: Filter by Manufacturer
+
+```python
+df = spark.read.format("openfda").option("limit", "200").load()
+top_manufacturers = df.filter("manufacturer_name != ''").groupBy("manufacturer_name").count()
+top_manufacturers.orderBy("count", ascending=False).show(10, truncate=30)
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .openfda import OpenFdaDataSource

--- a/pyspark_datasources/openfda.py
+++ b/pyspark_datasources/openfda.py
@@ -1,0 +1,95 @@
+"""OpenFDA data source - reads drug, food, and device data from the FDA API."""
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+
+class OpenFdaDataSource(DataSource):
+    """
+    A DataSource for reading data from the OpenFDA API.
+
+    No API key required for reasonable usage. Supports drug labels, food recalls,
+    device events, and more.
+
+    Name: `openfda`
+
+    Schema: `id string, brand_name string, generic_name string, manufacturer_name string,
+    product_type string, purpose string, active_ingredient string, effective_time string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import OpenFdaDataSource
+    >>> spark.dataSource.register(OpenFdaDataSource)
+
+    Load drug labels (default, limit 100).
+
+    >>> spark.read.format("openfda").load().show()
+
+    Load food recalls.
+
+    >>> spark.read.format("openfda").option("endpoint", "food/event").load().show()
+
+    Limit results.
+
+    >>> spark.read.format("openfda").option("limit", "50").load().show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "openfda"
+
+    def schema(self):
+        return (
+            "id string, brand_name string, generic_name string, manufacturer_name string, "
+            "product_type string, purpose string, active_ingredient string, effective_time string"
+        )
+
+    def reader(self, schema):
+        return OpenFdaReader(self.options)
+
+
+class OpenFdaReader(DataSourceReader):
+    ENDPOINTS = ("drug/label", "food/event", "device/event")
+
+    def __init__(self, options):
+        self.options = options
+        self.endpoint = self.options.get("endpoint", "drug/label")
+        self.limit = int(self.options.get("limit", "100"))
+        self.limit = min(max(self.limit, 1), 1000)
+
+    def read(self, partition):
+        url = f"https://api.fda.gov/{self.endpoint}.json"
+        try:
+            response = requests.get(
+                url, params={"limit": self.limit}, timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+            results = data.get("results", [])
+
+            for r in results:
+                yield self._to_row(r)
+        except requests.RequestException:
+            return iter([])
+
+    def _to_row(self, r):
+        openfda = r.get("openfda") or {}
+        purpose = r.get("purpose") or []
+        active = r.get("active_ingredient") or []
+
+        def first(lst):
+            return lst[0] if lst else ""
+
+        return Row(
+            id=r.get("id", ""),
+            brand_name=first(openfda.get("brand_name")),
+            generic_name=first(openfda.get("generic_name")),
+            manufacturer_name=first(openfda.get("manufacturer_name")),
+            product_type=first(openfda.get("product_type")),
+            purpose=first(purpose),
+            active_ingredient=first(active),
+            effective_time=r.get("effective_time", ""),
+        )

--- a/tests/test_openfda.py
+++ b/tests/test_openfda.py
@@ -1,0 +1,33 @@
+"""Tests for OpenFdaDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import OpenFdaDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_openfda_datasource_registration(spark):
+    """Test that OpenFdaDataSource can be registered."""
+    spark.dataSource.register(OpenFdaDataSource)
+    assert OpenFdaDataSource.name() == "openfda"
+
+
+def test_openfda_read(spark):
+    """Test reading drug labels (integration test - uses real API)."""
+    spark.dataSource.register(OpenFdaDataSource)
+    try:
+        df = spark.read.format("openfda").option("limit", "5").load()
+        rows = df.collect()
+        assert len(rows) > 0
+        assert len(rows) <= 5
+        assert "brand_name" in df.columns
+        assert "purpose" in df.columns
+    except Exception as exc:
+        if "timeout" in str(exc).lower() or "connection" in str(exc).lower():
+            pytest.skip("Network unavailable")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading data from the [OpenFDA API](https://open.fda.gov/).

## Features
- **No API key required** for reasonable usage
- Endpoints: drug/label (default), food/event, device/event
- Limit option (1-1000, default 100)
- Schema: id, brand_name, generic_name, manufacturer_name, product_type, purpose, active_ingredient, effective_time

## Checklist
- [x] Implementation - [x] Tests - [x] Documentation

Made with [Cursor](https://cursor.com)