### PR TITLE
Add Reddit data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df.select("id", "title", "author").show()
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
+| `reddit` | Batch | — | Reddit subreddit posts | built-in | [→](examples/reddit.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 
 📚 **[See detailed examples →](docs/data-sources-guide.md)** · **[Copy-pastable examples →](examples/README.md)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
+| reddit | Batch | — | [reddit.md](reddit.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 
 These examples are designed for humans and AI agents to quickly generate working code.

--- a/examples/reddit.md
+++ b/examples/reddit.md
@@ -1,0 +1,40 @@
+# Reddit Data Source Example
+
+Read posts from Reddit subreddits. No credentials required for public subreddits.
+
+## Setup Credentials
+
+None required for public subreddits.
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import RedditDataSource
+
+spark = SparkSession.builder.appName("reddit-example").getOrCreate()
+spark.dataSource.register(RedditDataSource)
+```
+
+### Step 2: Read from r/python
+
+```python
+df = spark.read.format("reddit").load("python")
+df.select("title", "author", "score", "num_comments").show(10, truncate=40)
+```
+
+### Step 3: Limit Results
+
+```python
+df = spark.read.format("reddit").option("limit", "50").load("programming")
+df.count()
+```
+
+### Step 4: Top Posts by Score
+
+```python
+df = spark.read.format("reddit").load("python")
+df.orderBy("score", ascending=False).select("title", "score", "num_comments").show(5, truncate=50)
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .reddit import RedditDataSource

--- a/pyspark_datasources/reddit.py
+++ b/pyspark_datasources/reddit.py
@@ -1,0 +1,81 @@
+"""Reddit data source - reads posts from subreddits."""
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+USER_AGENT = "pyspark-datasources/1.0"
+
+
+class RedditDataSource(DataSource):
+    """
+    A DataSource for reading posts from Reddit subreddits.
+
+    No API key required for public subreddits. Path specifies subreddit (e.g. python).
+
+    Name: `reddit`
+
+    Schema: `id string, title string, author string, score int, num_comments int,
+    created_utc long, url string, selftext string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import RedditDataSource
+    >>> spark.dataSource.register(RedditDataSource)
+
+    Load posts from r/python.
+
+    >>> spark.read.format("reddit").load("python").show()
+
+    Limit results.
+
+    >>> spark.read.format("reddit").option("limit", "25").load("programming").show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "reddit"
+
+    def schema(self):
+        return (
+            "id string, title string, author string, score int, num_comments int, "
+            "created_utc long, url string, selftext string"
+        )
+
+    def reader(self, schema):
+        return RedditReader(self.options)
+
+
+class RedditReader(DataSourceReader):
+    def __init__(self, options):
+        self.options = options
+        self.subreddit = self.options.get("path") or "python"
+        self.limit = min(int(self.options.get("limit", "25")), 100)
+
+    def read(self, partition):
+        url = f"https://www.reddit.com/r/{self.subreddit}/.json"
+        headers = {"User-Agent": USER_AGENT}
+        try:
+            response = requests.get(
+                url, headers=headers, params={"limit": self.limit}, timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+            children = data.get("data", {}).get("children", [])
+
+            for child in children:
+                d = child.get("data", {})
+                yield Row(
+                    id=d.get("id", ""),
+                    title=d.get("title", ""),
+                    author=d.get("author", ""),
+                    score=d.get("score", 0),
+                    num_comments=d.get("num_comments", 0),
+                    created_utc=d.get("created_utc", 0),
+                    url=d.get("url", ""),
+                    selftext=(d.get("selftext") or "")[:1000],
+                )
+        except requests.RequestException:
+            return iter([])

--- a/tests/test_reddit.py
+++ b/tests/test_reddit.py
@@ -1,0 +1,33 @@
+"""Tests for RedditDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import RedditDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_reddit_datasource_registration(spark):
+    """Test that RedditDataSource can be registered."""
+    spark.dataSource.register(RedditDataSource)
+    assert RedditDataSource.name() == "reddit"
+
+
+def test_reddit_read(spark):
+    """Test reading subreddit posts (integration - uses real API)."""
+    spark.dataSource.register(RedditDataSource)
+    try:
+        df = spark.read.format("reddit").option("limit", "5").load("python")
+        rows = df.collect()
+        assert len(rows) > 0
+        assert "title" in df.columns
+        assert "author" in df.columns
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "429" in msg or "timeout" in msg or "connection" in msg or "blocked" in msg:
+            pytest.skip("Reddit API unavailable or rate limited")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading posts from Reddit subreddits.

## Features
- No API key for public subreddits
- Path = subreddit name (e.g. load("python"))
- Limit option (default 25, max 100)
- Schema: id, title, author, score, num_comments, created_utc, url, selftext

Made with [Cursor](https://cursor.com)