### PR TITLE
Add Docker Hub data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ df.select("id", "title", "author").show()
 | `sftp` | Batch | Batch | Read/write files from SFTP server | `pip install pyspark-data-sources[sftp]` | [→](examples/sftp.md) |
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
+| `dockerhub` | Batch | — | Docker image tags from Docker Hub | built-in | [→](examples/dockerhub.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | sftp | Batch | Batch | [sftp.md](sftp.md) |
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
+| dockerhub | Batch | — | [dockerhub.md](dockerhub.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 

--- a/examples/dockerhub.md
+++ b/examples/dockerhub.md
@@ -1,0 +1,40 @@
+# Docker Hub Data Source Example
+
+Read Docker image tags from Docker Hub. No credentials required for public images.
+
+## Setup Credentials
+
+None required for public repositories.
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import DockerHubDataSource
+
+spark = SparkSession.builder.appName("dockerhub-example").getOrCreate()
+spark.dataSource.register(DockerHubDataSource)
+```
+
+### Step 2: Read Tags for Redis
+
+```python
+df = spark.read.format("dockerhub").load("library/redis")
+df.select("name", "full_size", "last_updated").show(10, truncate=False)
+```
+
+### Step 3: Custom Page Size
+
+```python
+df = spark.read.format("dockerhub").option("page_size", "50").load("nginx")
+df.count()
+```
+
+### Step 4: Largest Images
+
+```python
+df = spark.read.format("dockerhub").load("library/python")
+df.orderBy("full_size", ascending=False).select("name", "full_size").show(5)
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .dockerhub import DockerHubDataSource

--- a/pyspark_datasources/dockerhub.py
+++ b/pyspark_datasources/dockerhub.py
@@ -1,0 +1,77 @@
+"""Docker Hub data source - reads image tags from Docker Hub API."""
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+
+class DockerHubDataSource(DataSource):
+    """
+    A DataSource for reading Docker image tags from Docker Hub.
+
+    No API key required for public images. Path = repository (e.g. library/redis).
+
+    Name: `dockerhub`
+
+    Schema: `name string, digest string, full_size long, last_updated string,
+    last_updater_username string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import DockerHubDataSource
+    >>> spark.dataSource.register(DockerHubDataSource)
+
+    Load tags for redis image.
+
+    >>> spark.read.format("dockerhub").load("library/redis").show()
+
+    Limit page size.
+
+    >>> spark.read.format("dockerhub").option("page_size", "50").load("nginx").show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "dockerhub"
+
+    def schema(self):
+        return (
+            "name string, digest string, full_size long, last_updated string, "
+            "last_updater_username string"
+        )
+
+    def reader(self, schema):
+        return DockerHubReader(self.options)
+
+
+class DockerHubReader(DataSourceReader):
+    def __init__(self, options):
+        self.options = options
+        path = self.options.get("path") or "library/nginx"
+        if "/" not in path:
+            path = f"library/{path}"
+        self.repository = path
+        self.page_size = min(int(self.options.get("page_size", "100")), 100)
+
+    def read(self, partition):
+        url = f"https://hub.docker.com/v2/repositories/{self.repository}/tags"
+        try:
+            response = requests.get(
+                url, params={"page_size": self.page_size}, timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+            results = data.get("results", [])
+
+            for r in results:
+                yield Row(
+                    name=r.get("name", ""),
+                    digest=r.get("digest", ""),
+                    full_size=r.get("full_size", 0),
+                    last_updated=r.get("last_updated", ""),
+                    last_updater_username=r.get("last_updater_username", ""),
+                )
+        except requests.RequestException:
+            return iter([])

--- a/tests/test_dockerhub.py
+++ b/tests/test_dockerhub.py
@@ -1,0 +1,33 @@
+"""Tests for DockerHubDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import DockerHubDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_dockerhub_datasource_registration(spark):
+    """Test that DockerHubDataSource can be registered."""
+    spark.dataSource.register(DockerHubDataSource)
+    assert DockerHubDataSource.name() == "dockerhub"
+
+
+def test_dockerhub_read(spark):
+    """Test reading Docker image tags (integration - uses real API)."""
+    spark.dataSource.register(DockerHubDataSource)
+    try:
+        df = spark.read.format("dockerhub").option("page_size", "5").load("library/redis")
+        rows = df.collect()
+        assert len(rows) > 0
+        assert "name" in df.columns
+        assert "digest" in df.columns
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "timeout" in msg or "connection" in msg:
+            pytest.skip("Docker Hub API unavailable")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading Docker image tags from Docker Hub.

## Features
- No API key for public images
- Path = repository (e.g. library/redis, nginx)
- page_size option (default 100)
- Schema: name, digest, full_size, last_updated, last_updater_username

Made with [Cursor](https://cursor.com)