### PR TITLE
Add PyPI data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df.select("id", "title", "author").show()
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
+| `pypi` | Batch | — | Python package metadata from PyPI | built-in | [→](examples/pypi.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 
 📚 **[See detailed examples →](docs/data-sources-guide.md)** · **[Copy-pastable examples →](examples/README.md)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
+| pypi | Batch | — | [pypi.md](pypi.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 
 These examples are designed for humans and AI agents to quickly generate working code.

--- a/examples/pypi.md
+++ b/examples/pypi.md
@@ -1,0 +1,37 @@
+# PyPI Data Source Example
+
+Read Python package metadata from PyPI. No credentials required.
+
+## Setup Credentials
+
+None required.
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import PyPiDataSource
+
+spark = SparkSession.builder.appName("pypi-example").getOrCreate()
+spark.dataSource.register(PyPiDataSource)
+```
+
+### Step 2: Read Package Info
+
+```python
+df = spark.read.format("pypi").load("requests")
+df.select("package_name", "version", "summary", "author").show(truncate=50)
+```
+
+### Step 3: Read Multiple Packages (in a loop)
+
+```python
+packages = ["requests", "numpy", "pandas"]
+dfs = [spark.read.format("pypi").load(p) for p in packages]
+combined = dfs[0]
+for df in dfs[1:]:
+    combined = combined.union(df)
+combined.show()
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .pypi import PyPiDataSource

--- a/pyspark_datasources/pypi.py
+++ b/pyspark_datasources/pypi.py
@@ -1,0 +1,81 @@
+"""PyPI data source - reads Python package metadata from PyPI."""
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+
+class PyPiDataSource(DataSource):
+    """
+    A DataSource for reading Python package metadata from PyPI.
+
+    No API key required. Path specifies package name (e.g. requests).
+
+    Name: `pypi`
+
+    Schema: `package_name string, version string, summary string, author string,
+    license string, requires_python string, upload_time string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import PyPiDataSource
+    >>> spark.dataSource.register(PyPiDataSource)
+
+    Load package info for requests.
+
+    >>> spark.read.format("pypi").load("requests").show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "pypi"
+
+    def schema(self):
+        return (
+            "package_name string, version string, summary string, author string, "
+            "license string, requires_python string, upload_time string"
+        )
+
+    def reader(self, schema):
+        return PyPiReader(self.options)
+
+
+class PyPiReader(DataSourceReader):
+    def __init__(self, options):
+        self.options = options
+        self.package = self.options.get("path") or "requests"
+
+    def read(self, partition):
+        url = f"https://pypi.org/pypi/{self.package}/json"
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            data = response.json()
+
+            if "message" in data and "404" in str(data.get("message", "")):
+                return iter([])
+
+            info = data.get("info", {})
+            # Get latest version info from releases
+            releases = data.get("releases", {})
+            version = info.get("version", "")
+            upload_time = ""
+
+            if version and version in releases:
+                files = releases[version]
+                if files:
+                    upload_time = files[0].get("upload_time", "")
+
+            yield Row(
+                package_name=info.get("name", ""),
+                version=version,
+                summary=(info.get("summary") or "")[:500],
+                author=info.get("author", ""),
+                license=info.get("license", ""),
+                requires_python=info.get("requires_python", ""),
+                upload_time=upload_time,
+            )
+        except requests.RequestException:
+            return iter([])

--- a/tests/test_pypi.py
+++ b/tests/test_pypi.py
@@ -1,0 +1,34 @@
+"""Tests for PyPiDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import PyPiDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_pypi_datasource_registration(spark):
+    """Test that PyPiDataSource can be registered."""
+    spark.dataSource.register(PyPiDataSource)
+    assert PyPiDataSource.name() == "pypi"
+
+
+def test_pypi_read(spark):
+    """Test reading PyPI package (integration - uses real API)."""
+    spark.dataSource.register(PyPiDataSource)
+    try:
+        df = spark.read.format("pypi").load("requests")
+        rows = df.collect()
+        assert len(rows) == 1
+        assert rows[0]["package_name"] == "requests"
+        assert rows[0]["version"] != ""
+        assert "summary" in df.columns
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "timeout" in msg or "connection" in msg:
+            pytest.skip("PyPI API unavailable")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading Python package metadata from PyPI.

## Features
- No API key required
- Path = package name (e.g. requests)
- Schema: package_name, version, summary, author, license, requires_python, upload_time

Made with [Cursor](https://cursor.com)