### PR TITLE
Add RSS data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ df.select("id", "title", "author").show()
 | `oracle` | Batch | Batch | Read/write Oracle databases | `pip install pyspark-data-sources[oracledb]` | [→](examples/oracle.md) |
 | `stock` | Batch | — | Fetch stock market data (Alpha Vantage) | built-in | [→](examples/stock.md) |
 | `jsonplaceholder` | Batch | — | Read JSON data for testing | built-in | [→](examples/jsonplaceholder.md) |
+| `rss` | Batch | — | RSS/Atom feed items | built-in | [→](examples/rss.md) |
 | `weather` | Batch | — | Read current weather data (OpenWeatherMap) | built-in | [→](examples/weather.md) |
 
 📚 **[See detailed examples →](docs/data-sources-guide.md)** · **[Copy-pastable examples →](examples/README.md)**

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,6 +25,7 @@ Each markdown file in this folder contains end-to-end, copy-pastable examples fo
 | oracle | Batch | Batch | [oracle.md](oracle.md) |
 | stock | Batch | — | [stock.md](stock.md) |
 | jsonplaceholder | Batch | — | [jsonplaceholder.md](jsonplaceholder.md) |
+| rss | Batch | — | [rss.md](rss.md) |
 | weather | Stream | — | [weather.md](weather.md) |
 
 These examples are designed for humans and AI agents to quickly generate working code.

--- a/examples/rss.md
+++ b/examples/rss.md
@@ -1,0 +1,40 @@
+# RSS Data Source Example
+
+Read RSS/Atom feed items. No credentials required.
+
+## Setup Credentials
+
+None required.
+
+## End-to-End Pipeline: Batch Read
+
+### Step 1: Create Spark Session and Register Data Source
+
+```python
+from pyspark.sql import SparkSession
+from pyspark_datasources import RssDataSource
+
+spark = SparkSession.builder.appName("rss-example").getOrCreate()
+spark.dataSource.register(RssDataSource)
+```
+
+### Step 2: Read Hacker News RSS (Default)
+
+```python
+df = spark.read.format("rss").load()
+df.select("title", "link", "pub_date").show(10, truncate=40)
+```
+
+### Step 3: Read Custom Feed
+
+```python
+df = spark.read.format("rss").load("https://hnrss.org/frontpage")
+df.count()
+```
+
+### Step 4: Filter by Keyword
+
+```python
+df = spark.read.format("rss").load()
+df.filter("lower(title) LIKE '%python%'").select("title", "link").show(5, truncate=50)
+```

--- a/pyspark_datasources/__init__.py
+++ b/pyspark_datasources/__init__.py
@@ -15,3 +15,4 @@ from .sftp import SFTPDataSource
 from .jira import JiraDataSource
 from .oracle import OracleDataSource
 from .notion import NotionDataSource
+from .rss import RssDataSource

--- a/pyspark_datasources/rss.py
+++ b/pyspark_datasources/rss.py
@@ -1,0 +1,115 @@
+"""RSS data source - reads RSS/Atom feed items."""
+
+import re
+import xml.etree.ElementTree as ET
+
+import requests
+from pyspark.sql import Row
+from pyspark.sql.datasource import DataSource, DataSourceReader
+
+DEFAULT_FEED = "https://hnrss.org/frontpage"
+
+
+def _text(elem):
+    """Get text from element, handling CDATA."""
+    if elem is None:
+        return ""
+    text = elem.text or ""
+    for child in elem:
+        text += child.tail or ""
+    return text.strip()
+
+
+def _strip_html(text):
+    """Remove HTML tags from text."""
+    return re.sub(r"<[^>]+>", "", text)[:500] if text else ""
+
+
+class RssDataSource(DataSource):
+    """
+    A DataSource for reading RSS/Atom feed items.
+
+    No API key required. Path specifies feed URL.
+
+    Name: `rss`
+
+    Schema: `title string, link string, description string, pub_date string, guid string`
+
+    Examples
+    --------
+    Register the data source.
+
+    >>> from pyspark_datasources import RssDataSource
+    >>> spark.dataSource.register(RssDataSource)
+
+    Load Hacker News RSS (default).
+
+    >>> spark.read.format("rss").load().show()
+
+    Load custom feed.
+
+    >>> spark.read.format("rss").load("https://news.ycombinator.com/rss").show()
+    """
+
+    @classmethod
+    def name(cls):
+        return "rss"
+
+    def schema(self):
+        return (
+            "title string, link string, description string, pub_date string, guid string"
+        )
+
+    def reader(self, schema):
+        return RssReader(self.options)
+
+
+class RssReader(DataSourceReader):
+    def __init__(self, options):
+        self.options = options
+        self.feed_url = self.options.get("path") or DEFAULT_FEED
+
+    def read(self, partition):
+        try:
+            response = requests.get(self.feed_url, timeout=30)
+            response.raise_for_status()
+            root = ET.fromstring(response.content)
+
+            # Handle RSS 2.0 and Atom namespace
+            items = root.findall(".//item") or root.findall(
+                ".//{http://www.w3.org/2005/Atom}entry"
+            )
+
+            for item in items:
+                ns = {"dc": "http://purl.org/dc/elements/1.1/"}
+                title_el = item.find("title") or item.find(
+                    "{http://www.w3.org/2005/Atom}title"
+                )
+                link_el = item.find("link") or item.find(
+                    "{http://www.w3.org/2005/Atom}link"
+                )
+                desc_el = item.find("description") or item.find(
+                    "{http://www.w3.org/2005/Atom}summary"
+                )
+                pub_el = (
+                    item.find("pubDate")
+                    or item.find("dc:date", ns)
+                    or item.find("{http://www.w3.org/2005/Atom}updated")
+                )
+                guid_el = item.find("guid") or item.find(
+                    "{http://www.w3.org/2005/Atom}id"
+                )
+
+                link = ""
+                if link_el is not None:
+                    link = link_el.get("href", _text(link_el))
+
+                yield Row(
+                    title=_strip_html(_text(title_el)),
+                    link=link,
+                    description=_strip_html(_text(desc_el)),
+                    pub_date=_text(pub_el),
+                    guid=_text(guid_el),
+                )
+        except (requests.RequestException, ET.ParseError):
+            return iter([])

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,0 +1,33 @@
+"""Tests for RssDataSource."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pyspark_datasources import RssDataSource
+
+
+@pytest.fixture
+def spark():
+    return SparkSession.builder.master("local[1]").getOrCreate()
+
+
+def test_rss_datasource_registration(spark):
+    """Test that RssDataSource can be registered."""
+    spark.dataSource.register(RssDataSource)
+    assert RssDataSource.name() == "rss"
+
+
+def test_rss_read(spark):
+    """Test reading RSS feed (integration - uses real API)."""
+    spark.dataSource.register(RssDataSource)
+    try:
+        df = spark.read.format("rss").load()
+        rows = df.collect()
+        assert len(rows) > 0
+        assert "title" in df.columns
+        assert "link" in df.columns
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "timeout" in msg or "connection" in msg:
+            pytest.skip("RSS feed unavailable")
+        raise


### PR DESCRIPTION
## Summary
Adds a new data source for reading RSS/Atom feed items.

## Features
- No API key required
- Path = feed URL (default: Hacker News RSS)
- Schema: title, link, description, pub_date, guid
- Supports RSS 2.0 and Atom

Made with [Cursor](https://cursor.com)