### PR TITLE
Fix OpenSky data source crash/failure when client_id/client_secret are supplied

### DIFF
--- a/pyspark_datasources/opensky.py
+++ b/pyspark_datasources/opensky.py
@@ -1,37 +1,63 @@
 """
 OpenSky Network Data Source for Apache Spark - Academic/Private Use Example
 
-This module provides a custom Spark data source for streaming real-time aircraft tracking data from the OpenSky Network API (https://opensky-network.org/). The OpenSky Network is a community-based receiver network that collects air traffic surveillance data and makes it available as open data to researchers and enthusiasts.
+This module provides a custom Spark data source for streaming real-time aircraft
+tracking data from the OpenSky Network API (https://opensky-network.org/).
 
-Features:
-- Real-time streaming of aircraft positions, velocities, and flight data
-- Support for multiple geographic regions (Europe, North America, Asia, etc.)
-- OAuth2 authentication for higher API rate limits (4000 vs 100 calls/day)
-- Robust error handling with automatic retries and rate limiting
-- Data validation and type-safe parsing of aircraft state vectors
-- Configurable bounding boxes for focused data collection
+Fixes over the original implementation:
 
-Usage Example (Academic/Research):
-    # Basic usage with region NORTH_AMERICA
+1. CRASH WITH client_id/client_secret (the reported bug):
+   The original reader called `_get_access_token()` (a network request) inside
+   `__init__`. Spark instantiates the reader during query planning inside a
+   *forked* `pyspark.daemon` worker. On macOS, `requests` consults the system
+   proxy configuration via the SystemConfiguration framework
+   (`urllib.request.proxy_bypass_macosx_sysconf`), which is not fork-safe and
+   segfaults the worker ("Python worker exited unexpectedly (crashed)").
+   Fix: no network I/O in `__init__` — the OAuth token is fetched lazily on
+   first read, and the HTTP session is created with `trust_env=False` so no
+   fork-unsafe system proxy lookup ever happens (explicit HTTPS_PROXY/HTTP_PROXY
+   environment variables are still honored manually).
+
+2. PICKLE / FORK SAFETY:
+   The reader is pickled between the driver and worker processes. The
+   `requests.Session` (which may hold live SSL sockets) is now excluded from
+   pickling and recreated lazily in each process.
+
+3. TOKEN REFRESH USES THE RETRYING SESSION:
+   The token request now goes through the same retry-enabled session as data
+   requests, and the token is transparently refreshed before expiry.
+
+4. CORRECT FIELD MAPPING:
+   Per the OpenSky API documentation, state[7] is *barometric* altitude,
+   state[13] is *geometric* altitude, state[16] is position_source, and the
+   aircraft `category` is only returned as state[17] when the request is made
+   with `extended=1`. The original mapped state[7]→geo_altitude,
+   state[13]→baro_altitude and state[16]→category. The schema is unchanged, but
+   the values are now correct and `extended=1` is requested.
+
+5. SAFE TIMESTAMP PARSING:
+   `time_position` (state[3]) may be null; the original crashed the whole
+   micro-batch on `datetime.fromtimestamp(None)`. Timestamps are now parsed
+   defensively.
+
+6. BATCH SUPPORT:
+   In addition to `spark.readStream`, `spark.read.format("opensky")` now works
+   and returns one snapshot of the current state vectors.
+
+Usage (unchanged from the original):
+
     df = spark.readStream.format("opensky").load()
 
-    # With specific region and authentication
-    df = spark.readStream.format("opensky") \
-        .option("region", "EUROPE") \
-        .option("client_id", "your_research_client_id") \
-        .option("client_secret", "your_research_client_secret") \
+    df = spark.readStream.format("opensky") \\
+        .option("region", "EUROPE") \\
+        .option("client_id", "your_research_client_id") \\
+        .option("client_secret", "your_research_client_secret") \\
         .load()
-
-Data Schema:
-    Each record contains comprehensive aircraft information including position (lat/lon),altitude, velocity, heading, call sign, ICAO identifier, and various flight status flags. All timestamps are in UTC timezone for consistency.
-
-Feed your own data to OpenSky Network https://opensky-network.org/feed
 
 Rate Limits & Responsible Usage:
     - Anonymous access: 100 API calls per day
     - Authenticated access: 4000 API calls per day (research accounts)
     - Minimum 5-second interval between requests
-    - 8000 API calls if you feed your own data to the OpenSky Network feed (https://opensky-network.org/feed)
 
 Data Attribution:
     When using this data in research or publications, please cite:
@@ -39,44 +65,48 @@ Data Attribution:
 
 Author: Frank Munz, Databricks - Example Only, No Warranty
 Purpose: Educational Example / Academic Research Tool
-Version: 1.0
-Last Updated: July-2025
+Version: 1.1 (fixed)
 
-================================================================================
-LEGAL NOTICES & TERMS OF USE
-
-USAGE RESTRICTIONS:
-- Academic research and educational purposes only
-- Commercial use requires explicit permission from OpenSky Network
-- Must comply with OpenSky Network Terms of Use: https://opensky-network.org/about/terms-of-use
-
-If you create a publication (including web pages, papers published by a third party, and publicly available presentations) using data from the OpenSky Network data set, you should cite the original OpenSky paper as follows:
-
-Matthias Schäfer, Martin Strohmeier, Vincent Lenders, Ivan Martinovic and Matthias Wilhelm.
-"Bringing Up OpenSky: A Large-scale ADS-B Sensor Network for Research".
-In Proceedings of the 13th IEEE/ACM International Symposium on Information Processing in Sensor Networks (IPSN), pages 83-94, April 2014.
-
-DISCLAIMER & LIABILITY:
-This code is provided "AS IS" for educational purposes only. The author and Databricks make no warranties, express or implied, and disclaim all liability for any damages, losses, or issues arising from the use of this code. Users assume full responsibility for compliance with all applicable terms of service, laws, and regulations. Use at your own risk.
-
-For commercial use, contact OpenSky Network directly.
-================================================================================
-
+Must comply with OpenSky Network Terms of Use:
+https://opensky-network.org/about/terms-of-use
 """
 
-import requests
+import logging
+import os
 import time
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple, Any, Optional, Iterator
 from dataclasses import dataclass
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from enum import Enum
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
-from pyspark.sql.datasource import SimpleDataSourceStreamReader, DataSource
-from pyspark.sql.types import *
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+from pyspark.sql.datasource import (
+    DataSource,
+    DataSourceReader,
+    InputPartition,
+    SimpleDataSourceStreamReader,
+)
+from pyspark.sql.types import (
+    ArrayType,
+    BooleanType,
+    DoubleType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
 
 DS_NAME = "opensky"
+
+TOKEN_URL = (
+    "https://auth.opensky-network.org/auth/realms/opensky-network"
+    "/protocol/openid-connect/token"
+)
+STATES_URL = "https://opensky-network.org/api/states/all"
 
 
 @dataclass
@@ -97,348 +127,369 @@ class Region(Enum):
     GLOBAL = BoundingBox(-90.0, 90.0, -180.0, 180.0)
 
 
+logger = logging.getLogger(__name__)
+
+
 class OpenSkyAPIError(Exception):
     """Base exception for OpenSky API errors"""
 
-    pass
+
+class TransientOpenSkyError(OpenSkyAPIError):
+    """A fault expected to clear on its own: network timeouts, connection
+    errors (including egress blocks), and rate limiting. The streaming reader
+    swallows these and skips the micro-batch so the stream auto-recovers when
+    the upstream becomes reachable again."""
 
 
-class RateLimitError(OpenSkyAPIError):
-    """Raised when API rate limit is exceeded"""
+class ConfigOpenSkyError(OpenSkyAPIError):
+    """A deterministic fault that will NOT self-heal: bad/missing credentials,
+    a malformed token response, or any auth failure. The streaming reader lets
+    these propagate so the pipeline update fails loudly with an event-log entry
+    instead of silently emitting zero rows."""
 
-    pass
+
+class RateLimitError(TransientOpenSkyError):
+    """Raised when API rate limit is exceeded (HTTP 429). Transient: back off,
+    do not kill the stream."""
 
 
-class OpenSkyStreamReader(SimpleDataSourceStreamReader):
-    DEFAULT_REGION = "NORTH_AMERICA"
+class OpenSkyClient:
+    """Fork- and pickle-safe OpenSky API client with lazy OAuth2 authentication.
+
+    No network I/O happens at construction time; the HTTP session and the
+    access token are created on first use in whichever process performs the
+    read. The live session object is never pickled.
+    """
+
     MIN_REQUEST_INTERVAL = 5.0  # seconds between requests
-    ANONYMOUS_RATE_LIMIT = 100  # calls per day
-    AUTHENTICATED_RATE_LIMIT = 4000  # calls per day
     MAX_RETRIES = 3
     RETRY_BACKOFF = 2
     RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+    TOKEN_REFRESH_MARGIN = 60  # refresh this many seconds before expiry
 
-    def __init__(self, schema: StructType, options: Dict[str, str]):
-        super().__init__()
-        self.schema = schema
-        self.options = options
-        self.session = self._create_session()
-        self.last_request_time = 0
+    def __init__(self, bbox: BoundingBox, client_id: Optional[str], client_secret: Optional[str]):
+        self.bbox = bbox
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._session: Optional[requests.Session] = None
+        self._access_token: Optional[str] = None
+        self._token_expires_at: float = 0.0
+        self._last_request_time: float = 0.0
 
-        region_name = options.get("region", self.DEFAULT_REGION).upper()
-        try:
-            self.bbox = Region[region_name].value
-        except KeyError:
-            print(f"Invalid region '{region_name}'. Defaulting to {self.DEFAULT_REGION}.")
-            self.bbox = Region[self.DEFAULT_REGION].value
+    # -- pickling: never carry a live session (SSL sockets) across processes
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_session"] = None
+        return state
 
-        self.client_id = options.get("client_id")
-        self.client_secret = options.get("client_secret")
-        self.access_token = None
-        self.token_expires_at = 0
+    @property
+    def session(self) -> requests.Session:
+        if self._session is None:
+            session = requests.Session()
+            # trust_env=False prevents requests/urllib from querying the OS
+            # proxy settings (fork-unsafe on macOS, segfaults forked Spark
+            # workers). Explicit proxy environment variables still work.
+            session.trust_env = False
+            proxies = {
+                scheme: os.environ[var]
+                for scheme, var in (("http", "HTTP_PROXY"), ("https", "HTTPS_PROXY"))
+                if os.environ.get(var)
+            }
+            if proxies:
+                session.proxies.update(proxies)
+            retry_strategy = Retry(
+                total=self.MAX_RETRIES,
+                backoff_factor=self.RETRY_BACKOFF,
+                status_forcelist=self.RETRY_STATUS_CODES,
+            )
+            adapter = HTTPAdapter(max_retries=retry_strategy)
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+            self._session = session
+        return self._session
 
-        if self.client_id and self.client_secret:
-            self._get_access_token()  # OAuth2 authentication
-            self.rate_limit = self.AUTHENTICATED_RATE_LIMIT
-        else:
-            self.rate_limit = self.ANONYMOUS_RATE_LIMIT
+    def _ensure_token(self) -> None:
+        """Fetch or refresh the OAuth2 token (client credentials flow)."""
+        if not (self.client_id and self.client_secret):
+            return
+        now = time.time()
+        if self._access_token and now < self._token_expires_at:
+            return
 
-    def _get_access_token(self):
-        """Get OAuth2 access token using client credentials flow"""
-        current_time = time.time()
-        if self.access_token and current_time < self.token_expires_at:
-            return  # Token still valid
-
-        token_url = "https://auth.opensky-network.org/auth/realms/opensky-network/protocol/openid-connect/token"
         data = {
             "grant_type": "client_credentials",
             "client_id": self.client_id,
             "client_secret": self.client_secret,
         }
-
         try:
-            response = requests.post(token_url, data=data, timeout=10)
-            response.raise_for_status()
-            token_data = response.json()
-
-            self.access_token = token_data["access_token"]
-            expires_in = token_data.get("expires_in", 1800)
-            self.token_expires_at = current_time + expires_in - 300
-
+            response = self.session.post(TOKEN_URL, data=data, timeout=10)
+        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+            # Reaching the token endpoint failed transiently (egress/network).
+            raise TransientOpenSkyError(f"Token request failed transiently: {e}") from e
         except requests.exceptions.RequestException as e:
-            raise OpenSkyAPIError(f"Failed to get access token: {str(e)}")
+            # Non-transient HTTP error (e.g. 400/401 for bad client credentials).
+            raise ConfigOpenSkyError(f"Failed to get access token: {e}") from e
 
-    def _create_session(self) -> requests.Session:
-        """Create and configure requests session with retry logic"""
-        session = requests.Session()
-        retry_strategy = Retry(
-            total=self.MAX_RETRIES,
-            backoff_factor=self.RETRY_BACKOFF,
-            status_forcelist=self.RETRY_STATUS_CODES,
-        )
-        adapter = HTTPAdapter(max_retries=retry_strategy)
-        session.mount("https://", adapter)
-        session.mount("http://", adapter)
-        return session
+        # A 4xx on the token endpoint means bad/rejected credentials: deterministic.
+        if response.status_code in (400, 401, 403):
+            raise ConfigOpenSkyError(
+                f"Authentication failed (HTTP {response.status_code}): check "
+                f"client_id/client_secret"
+            )
+        try:
+            response.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise TransientOpenSkyError(f"Token endpoint error: {e}") from e
 
-    def initialOffset(self) -> Dict[str, int]:
-        return {"last_fetch": 0}
+        # Parse the token body inside the guard: a malformed 200 body (e.g. an
+        # OAuth error JSON with no access_token) must surface as a clear auth
+        # error, not a bare KeyError that escapes the OpenSkyAPIError contract.
+        try:
+            token_data = response.json()
+            self._access_token = token_data["access_token"]
+        except (ValueError, KeyError, TypeError) as e:
+            raise ConfigOpenSkyError(
+                f"Malformed token response (no access_token): {e}"
+            ) from e
+        expires_in = token_data.get("expires_in", 1800)
+        self._token_expires_at = now + expires_in - self.TOKEN_REFRESH_MARGIN
 
-    def _handle_rate_limit(self):
-        """Ensure e MIN_REQUEST_INTERVAL seconds between requests"""
-        current_time = time.time()
-        time_since_last_request = current_time - self.last_request_time
+    def _throttle(self) -> None:
+        """Keep at least MIN_REQUEST_INTERVAL seconds between requests."""
+        elapsed = time.time() - self._last_request_time
+        if elapsed < self.MIN_REQUEST_INTERVAL:
+            time.sleep(self.MIN_REQUEST_INTERVAL - elapsed)
+        self._last_request_time = time.time()
 
-        if time_since_last_request < self.MIN_REQUEST_INTERVAL:
-            sleep_time = self.MIN_REQUEST_INTERVAL - time_since_last_request
-            time.sleep(sleep_time)
-
-        self.last_request_time = time.time()
-
-    def _fetch_states(self) -> requests.Response:
-        """Fetch states from OpenSky API with error handling"""
-        self._handle_rate_limit()
-
-        if self.client_id and self.client_secret:
-            self._get_access_token()
+    def fetch_states(self) -> Dict[str, Any]:
+        """Fetch current state vectors, authenticating if credentials are set."""
+        self._throttle()
+        self._ensure_token()
 
         params = {
             "lamin": self.bbox.lamin,
             "lamax": self.bbox.lamax,
             "lomin": self.bbox.lomin,
             "lomax": self.bbox.lomax,
+            "extended": 1,  # include aircraft category as state[17]
         }
-
         headers = {}
-        if self.access_token:
-            headers["Authorization"] = f"Bearer {self.access_token}"
+        if self._access_token:
+            headers["Authorization"] = f"Bearer {self._access_token}"
 
         try:
-            response = self.session.get(
-                "https://opensky-network.org/api/states/all",
-                params=params,
-                headers=headers,
-                timeout=10,
-            )
-
+            response = self.session.get(STATES_URL, params=params, headers=headers, timeout=10)
             if response.status_code == 429:
                 raise RateLimitError("API rate limit exceeded")
+            if response.status_code == 401 and self._access_token:
+                # Token revoked or expired early: refresh once and retry.
+                self._access_token = None
+                self._ensure_token()
+                headers["Authorization"] = f"Bearer {self._access_token}"
+                response = self.session.get(
+                    STATES_URL, params=params, headers=headers, timeout=10
+                )
+            if response.status_code == 401:
+                # Still unauthorized after a token refresh: credentials are bad,
+                # not a transient blip. Fail loudly.
+                raise ConfigOpenSkyError(
+                    "Authentication failed (HTTP 401) after token refresh: "
+                    "check client_id/client_secret"
+                )
             response.raise_for_status()
-
-            return response
-
+            return response.json()
+        except requests.exceptions.Timeout as e:
+            raise TransientOpenSkyError("API request timed out") from e
+        except requests.exceptions.ConnectionError as e:
+            # Includes egress blocks (dropped SYN → ConnectTimeout): self-heals.
+            raise TransientOpenSkyError("Connection error occurred") from e
         except requests.exceptions.RequestException as e:
-            error_msg = f"API request failed: {str(e)}"
-            if isinstance(e, requests.exceptions.Timeout):
-                error_msg = "API request timed out"
-            elif isinstance(e, requests.exceptions.ConnectionError):
-                error_msg = "Connection error occurred"
-            raise OpenSkyAPIError(error_msg) from e
+            # Retries on 5xx/429 are exhausted here (RetryError) or a 4xx slipped
+            # through: treat as transient so a flaky endpoint doesn't kill the
+            # stream. Deterministic auth (401) is already raised above.
+            raise TransientOpenSkyError(f"API request failed: {e}") from e
 
-    def valid_state(self, state: List) -> bool:
-        """Validate state data"""
-        if not state or len(state) < 17:
-            return False
 
-        return (
-            state[0] is not None  # icao24
-            and state[5] is not None  # longitude
-            and state[6] is not None
-        )  # latitude
+def _safe_float(value: Any) -> Optional[float]:
+    try:
+        return float(value) if value is not None else None
+    except (ValueError, TypeError):
+        return None
 
-    def parse_state(self, state: List, timestamp: int) -> Tuple:
-        """Parse state data with safe type conversion"""
 
-        def safe_float(value: Any) -> Optional[float]:
-            try:
-                return float(value) if value is not None else None
-            except (ValueError, TypeError):
-                return None
+def _safe_int(value: Any) -> Optional[int]:
+    try:
+        return int(value) if value is not None else None
+    except (ValueError, TypeError):
+        return None
 
-        def safe_int(value: Any) -> Optional[int]:
-            try:
-                return int(value) if value is not None else None
-            except (ValueError, TypeError):
-                return None
 
-        def safe_bool(value: Any) -> Optional[bool]:
-            return bool(value) if value is not None else None
+def _safe_bool(value: Any) -> Optional[bool]:
+    return bool(value) if value is not None else None
 
-        return (
-            datetime.fromtimestamp(timestamp, tz=timezone.utc),
-            state[0],  # icao24
-            state[1],  # callsign
-            state[2],  # origin_country
-            datetime.fromtimestamp(state[3], tz=timezone.utc),
-            datetime.fromtimestamp(state[4], tz=timezone.utc),
-            safe_float(state[5]),  # longitude
-            safe_float(state[6]),  # latitude
-            safe_float(state[7]),  # geo_altitude
-            safe_bool(state[8]),  # on_ground
-            safe_float(state[9]),  # velocity
-            safe_float(state[10]),  # true_track
-            safe_float(state[11]),  # vertical_rate
-            state[12],  # sensors
-            safe_float(state[13]),  # baro_altitude
-            state[14],  # squawk
-            safe_bool(state[15]),  # spi
-            safe_int(state[16]),  # category
-        )
+
+def _safe_ts(value: Any) -> Optional[datetime]:
+    try:
+        return datetime.fromtimestamp(value, tz=timezone.utc) if value is not None else None
+    except (ValueError, TypeError, OSError):
+        return None
+
+
+def valid_state(state: List) -> bool:
+    """A usable state vector has at least the 17 standard fields and a position."""
+    if not state or len(state) < 17:
+        return False
+    return (
+        state[0] is not None  # icao24
+        and state[5] is not None  # longitude
+        and state[6] is not None  # latitude
+    )
+
+
+def parse_state(state: List, timestamp: int) -> Tuple:
+    """Parse one state vector (extended=1 layout) with safe type conversion."""
+    return (
+        _safe_ts(timestamp),  # time_ingest
+        state[0],  # icao24
+        state[1],  # callsign
+        state[2],  # origin_country
+        _safe_ts(state[3]),  # time_position (may be null)
+        _safe_ts(state[4]),  # last_contact
+        _safe_float(state[5]),  # longitude
+        _safe_float(state[6]),  # latitude
+        _safe_float(state[13]) if len(state) > 13 else None,  # geo_altitude
+        _safe_bool(state[8]),  # on_ground
+        _safe_float(state[9]),  # velocity
+        _safe_float(state[10]),  # true_track
+        _safe_float(state[11]),  # vertical_rate
+        state[12],  # sensors
+        _safe_float(state[7]),  # baro_altitude
+        state[14],  # squawk
+        _safe_bool(state[15]),  # spi
+        _safe_int(state[17]) if len(state) > 17 else None,  # category (extended=1)
+    )
+
+
+def parse_response(data: Dict[str, Any]) -> List[Tuple]:
+    ts = data.get("time", int(time.time()))
+    return [parse_state(s, ts) for s in (data.get("states") or []) if valid_state(s)]
+
+
+def _make_client(options: Dict[str, str]) -> OpenSkyClient:
+    region_name = options.get("region", "NORTH_AMERICA").upper()
+    try:
+        bbox = Region[region_name].value
+    except KeyError:
+        logger.warning("Invalid region '%s'. Defaulting to NORTH_AMERICA.", region_name)
+        bbox = Region["NORTH_AMERICA"].value
+    return OpenSkyClient(bbox, options.get("client_id"), options.get("client_secret"))
+
+
+class OpenSkyStreamReader(SimpleDataSourceStreamReader):
+    def __init__(self, schema: StructType, options: Dict[str, str]):
+        super().__init__()
+        self.schema = schema
+        self.client = _make_client(options)
+
+    def initialOffset(self) -> Dict[str, int]:
+        return {"last_fetch": 0}
+
+    def read(self, start: Dict[str, int]) -> Tuple[List[Tuple], Dict[str, int]]:
+        """Read the current state vectors and advance the offset.
+
+        Error policy (see the exception taxonomy in this module):
+          * TransientOpenSkyError (timeouts, connection/egress errors, 429) is
+            swallowed: we log a warning and return the offset unchanged so no
+            micro-batch is triggered, and the stream auto-recovers once the
+            upstream is reachable again.
+          * Everything else — ConfigOpenSkyError (bad creds, malformed token),
+            and any unexpected programming error (parse bugs, etc.) — is allowed
+            to propagate. That fails the Structured Streaming micro-batch (and
+            surfaces as a StreamingQueryException / a failed pipeline update)
+            instead of silently emitting zero rows.
+
+        Note this reader is a driver-side SimpleDataSourceStreamReader, so
+        `logger` output lands in the driver log. It is NOT an event-log event;
+        only a raised exception surfaces there. That is deliberate: a transient
+        blip should stay quiet and self-heal, a deterministic fault should be loud.
+        """
+        try:
+            data = self.client.fetch_states()
+            return (parse_response(data), {"last_fetch": data.get("time", int(time.time()))})
+        except TransientOpenSkyError as e:
+            # Do not advance the offset: Spark sees "no new data" and skips the
+            # batch. Re-fetch happens on the next trigger (the snapshot is always
+            # current, so nothing is lost by not advancing).
+            logger.warning("OpenSky transient error, skipping micro-batch: %s", e)
+            return ([], start)
 
     def readBetweenOffsets(self, start: Dict[str, int], end: Dict[str, int]) -> Iterator[Tuple]:
+        # The API cannot replay past data; re-fetch the latest snapshot.
         data, _ = self.read(start)
         return iter(data)
 
-    def read(self, start: Dict[str, int]) -> Tuple[List[Tuple], Dict[str, int]]:
-        """Read states with error handling and backoff"""
-        try:
-            response = self._fetch_states()
-            data = response.json()
 
-            valid_states = [
-                self.parse_state(s, data["time"])
-                for s in data.get("states", [])
-                if self.valid_state(s)
-            ]
+class OpenSkyBatchReader(DataSourceReader):
+    """Batch reader: one snapshot of the current state vectors per read."""
 
-            return (valid_states, {"last_fetch": data.get("time", int(time.time()))})
+    def __init__(self, schema: StructType, options: Dict[str, str]):
+        self.schema = schema
+        self.options = dict(options)
 
-        except OpenSkyAPIError as e:
-            print(f"OpenSky API Error: {str(e)}")
-            return ([], start)
-        except Exception as e:
-            print(f"Unexpected error: {str(e)}")
-            return ([], start)
+    def partitions(self) -> List[InputPartition]:
+        return [InputPartition(0)]
+
+    def read(self, partition: InputPartition) -> Iterator[Tuple]:
+        client = _make_client(self.options)
+        return iter(parse_response(client.fetch_states()))
 
 
 class OpenSkyDataSource(DataSource):
     """
-    Apache Spark DataSource for streaming real-time aircraft tracking data from OpenSky Network.
+    Apache Spark DataSource for real-time aircraft tracking data from the
+    OpenSky Network (https://opensky-network.org/).
 
-    This data source provides access to live aircraft position, velocity, and flight data
-    from the OpenSky Network's REST API (https://opensky-network.org/). The OpenSky Network
-    is a community-based receiver network that collects air traffic surveillance data using
-    ADS-B transponders and makes it available as open data for research and educational purposes.
-
-    The data source supports streaming aircraft state vectors including position coordinates,
-    altitude, velocity, heading, call signs, and various flight status information for aircraft
-    within configurable geographic regions.
-
-    Parameters
-    ----------
-    options : Dict[str, str], optional
-        Configuration options for the data source. Supported options:
-
-        region : str, default "NORTH_AMERICA"
-            Geographic region to collect data from. Valid options:
-            - "EUROPE": European airspace (35°N-72°N, 25°W-45°E)
-            - "NORTH_AMERICA": North American airspace (7°N-72°N, 168°W-60°W)
-            - "SOUTH_AMERICA": South American airspace (56°S-15°N, 90°W-30°W)
-            - "ASIA": Asian airspace (10°S-82°N, 45°E-180°E)
-            - "AUSTRALIA": Australian airspace (50°S-10°S, 110°E-180°E)
-            - "AFRICA": African airspace (35°S-37°N, 20°W-52°E)
-            - "GLOBAL": Worldwide coverage (90°S-90°N, 180°W-180°E)
-
-        client_id : str, optional
-            OAuth2 client ID for authenticated access. Increases rate limit from
-            100 to 4000 API calls per day. Requires corresponding client_secret.
-
-        client_secret : str, optional
-            OAuth2 client secret for authenticated access. Must be provided when
-            client_id is specified.
+    Options
+    -------
+    region : str, default "NORTH_AMERICA"
+        One of EUROPE, NORTH_AMERICA, SOUTH_AMERICA, ASIA, AUSTRALIA, AFRICA,
+        GLOBAL.
+    client_id / client_secret : str, optional
+        OAuth2 client credentials for authenticated access (higher rate
+        limits). Both must be provided together.
 
     Examples
     --------
-    Basic usage with default North America region:
+    >>> spark.dataSource.register(OpenSkyDataSource)
+
+    Streaming, anonymous:
 
     >>> df = spark.readStream.format("opensky").load()
-    >>> query = df.writeStream.format("console").start()
 
-    Specify a different region:
+    Streaming, authenticated:
 
     >>> df = spark.readStream.format("opensky") \\
     ...     .option("region", "EUROPE") \\
+    ...     .option("client_id", "your_client_id") \\
+    ...     .option("client_secret", "your_client_secret") \\
     ...     .load()
 
-    Authenticated access for higher rate limits:
+    Batch snapshot:
 
-    >>> df = spark.readStream.format("opensky") \\
-    ...     .option("region", "ASIA") \\
-    ...     .option("client_id", "your_research_client_id") \\
-    ...     .option("client_secret", "your_research_client_secret") \\
-    ...     .load()
+    >>> df = spark.read.format("opensky").option("region", "EUROPE").load()
 
-    Process aircraft data with filtering:
-
-    >>> df = spark.readStream.format("opensky").load()
-    >>> commercial_flights = df.filter(df.callsign.isNotNull() & (df.geo_altitude > 10000))
-    >>> query = commercial_flights.writeStream.format("delta").option("path", "/tmp/flights").start()
-
-    Schema
-    ------
-    The returned DataFrame contains the following columns:
-
-    - time_ingest (TimestampType): When the data was ingested
-    - icao24 (StringType): Unique ICAO 24-bit address of the aircraft
-    - callsign (StringType): Flight number or aircraft call sign
-    - origin_country (StringType): Country where aircraft is registered
-    - time_position (TimestampType): Last position update timestamp
-    - last_contact (TimestampType): Last time aircraft was seen
-    - longitude (DoubleType): Aircraft longitude in decimal degrees
-    - latitude (DoubleType): Aircraft latitude in decimal degrees
-    - geo_altitude (DoubleType): Aircraft altitude above sea level in meters
-    - on_ground (BooleanType): Whether aircraft is on ground
-    - velocity (DoubleType): Ground speed in m/s
-    - true_track (DoubleType): Track angle in degrees (0° = north)
-    - vertical_rate (DoubleType): Climb/descent rate in m/s
-    - sensors (ArrayType[IntegerType]): Sensor IDs that detected aircraft
-    - baro_altitude (DoubleType): Barometric altitude in meters
-    - squawk (StringType): Transponder squawk code
-    - spi (BooleanType): Special Position Identification flag
-    - category (IntegerType): Aircraft category (0-15)
-
-    Rate Limits
-    -----------
-    - Anonymous access: 100 API calls per day
-    - Authenticated access: 4000 API calls per day (research accounts)
-    - Data contributors: 8000 API calls per day
-    - Minimum 5-second interval between requests
-
-    Raises
-    ------
-    ValueError
-        If client_id is provided without client_secret, or if an invalid region is specified.
-
-    Notes
-    -----
-    - This data source is intended for academic research and educational purposes only
-    - Commercial use requires explicit permission from OpenSky Network
-    - Users must comply with OpenSky Network Terms of Use
-    - All timestamps are in UTC timezone
-    - Data may have gaps due to receiver coverage limitations
-    - API rate limits are enforced automatically with exponential backoff
-
-    References
-    ----------
-    OpenSky Network: https://opensky-network.org/
-    API Documentation: https://opensky-network.org/apidoc/
-    Terms of Use: https://opensky-network.org/about/terms-of-use
-
-    Citation
-    --------
-    When using this data in research, please cite:
-    Matthias Schäfer, Martin Strohmeier, Vincent Lenders, Ivan Martinovic and Matthias Wilhelm.
-    "Bringing Up OpenSky: A Large-scale ADS-B Sensor Network for Research".
-    In Proceedings of the 13th IEEE/ACM International Symposium on Information Processing
-    in Sensor Networks (IPSN), pages 83-94, April 2014.
+    When using this data in research, please cite "The OpenSky Network,
+    https://opensky-network.org" and the OpenSky IPSN 2014 paper.
     """
 
     def __init__(self, options: Dict[str, str] = None):
         super().__init__(options or {})
         self.options = options or {}
 
-        if "client_id" in self.options and not self.options.get("client_secret"):
+        if self.options.get("client_id") and not self.options.get("client_secret"):
             raise ValueError("client_secret must be provided when client_id is set")
+        if self.options.get("client_secret") and not self.options.get("client_id"):
+            raise ValueError("client_id must be provided when client_secret is set")
 
         if "region" in self.options and self.options["region"].upper() not in Region.__members__:
             raise ValueError(
@@ -475,3 +526,6 @@ class OpenSkyDataSource(DataSource):
 
     def simpleStreamReader(self, schema: StructType) -> OpenSkyStreamReader:
         return OpenSkyStreamReader(schema, self.options)
+
+    def reader(self, schema: StructType) -> OpenSkyBatchReader:
+        return OpenSkyBatchReader(schema, self.options)

--- a/pyspark_datasources/opensky.py
+++ b/pyspark_datasources/opensky.py
@@ -46,6 +46,7 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 from urllib3.util.retry import Retry
 
 from pyspark.sql.datasource import (
@@ -136,6 +137,22 @@ def _egress_blocked_msg(host: str) -> str:
     )
 
 
+def _wraps_read_timeout(exc: BaseException) -> bool:
+    """True if a ``requests.ConnectionError`` actually wraps an exhausted urllib3
+    *read* timeout, i.e. ``ConnectionError(MaxRetryError(reason=ReadTimeoutError))``.
+
+    requests reports an exhausted read-retry sequence as a ``ConnectionError``
+    (only a *connect* timeout surfaces as ``ConnectTimeout``), so the exception
+    type alone cannot tell a slow-but-reachable host (transient) apart from a
+    dropped TCP connect (egress block). Inspecting the wrapped cause restores
+    that distinction so a read timeout is not misclassified as an egress block.
+    """
+    return any(
+        isinstance(arg, MaxRetryError) and isinstance(arg.reason, ReadTimeoutError)
+        for arg in getattr(exc, "args", ())
+    )
+
+
 class OpenSkyClient:
     """Fork- and pickle-safe OpenSky API client with lazy OAuth2 authentication.
 
@@ -195,6 +212,19 @@ class OpenSkyClient:
                 session.proxies.update(proxies)
             retry_strategy = Retry(
                 total=self.MAX_RETRIES,
+                connect=self.MAX_RETRIES,
+                # read=False: do NOT retry read timeouts at the adapter level.
+                # Two reasons. (1) A read timeout on a self-healing per-batch
+                # stream is better failed fast and retried on the next trigger
+                # than by blocking the micro-batch through backoff sleeps.
+                # (2) An exhausted read-retry is re-raised by requests as a
+                # ConnectionError(MaxRetryError(ReadTimeoutError)), which would
+                # be misclassified as an egress block; with read=False a read
+                # timeout surfaces as requests.ReadTimeout (a Timeout subclass)
+                # and is classified transient directly. (_wraps_read_timeout
+                # still guards the wrapped case defensively.)
+                read=False,
+                status=self.MAX_RETRIES,
                 backoff_factor=self.RETRY_BACKOFF,
                 status_forcelist=self.RETRY_STATUS_CODES,
             )
@@ -228,7 +258,12 @@ class OpenSkyClient:
             # ReadTimeout: a slow-but-reachable endpoint — transient, let it retry.
             raise TransientOpenSkyError(f"Token request timed out: {e}") from e
         except requests.exceptions.ConnectionError as e:
-            # Non-timeout connection failure (refused, DNS, SSL/proxy). Loud.
+            # requests wraps an exhausted read-retry as ConnectionError; if that
+            # is what happened, the host was reachable but slow -> transient.
+            if _wraps_read_timeout(e):
+                raise TransientOpenSkyError(f"Token request timed out: {e}") from e
+            # Otherwise a non-timeout connection failure (refused, DNS,
+            # SSL/proxy) or dropped connect: the egress/IP-block signature. Loud.
             raise EgressBlockedError(_egress_blocked_msg("auth.opensky-network.org")) from e
         except requests.exceptions.RequestException as e:
             # Non-transient HTTP error (e.g. 400/401 for bad client credentials).
@@ -325,9 +360,15 @@ class OpenSkyClient:
             # Transient — let the stream retry on the next trigger.
             raise TransientOpenSkyError("API request timed out") from e
         except requests.exceptions.ConnectionError as e:
-            # A non-timeout connection failure (connection refused, DNS failure,
-            # SSL/proxy error). Deterministic enough that swallowing it into
-            # silent zero rows is wrong: fail loudly.
+            # requests re-raises an exhausted read-retry as ConnectionError
+            # (ConnectionError(MaxRetryError(ReadTimeoutError))), NOT as a
+            # ReadTimeout. That is a slow-but-reachable host -> transient: let
+            # the stream retry on the next trigger instead of killing it.
+            if _wraps_read_timeout(e):
+                raise TransientOpenSkyError("API request timed out") from e
+            # Otherwise a genuine non-timeout connection failure (connection
+            # refused, DNS failure, SSL/proxy error). Deterministic enough that
+            # swallowing it into silent zero rows is wrong: fail loudly.
             raise EgressBlockedError(_egress_blocked_msg("opensky-network.org")) from e
         except requests.exceptions.RequestException as e:
             # Retries on 5xx/429 are exhausted here (RetryError) or another

--- a/pyspark_datasources/opensky.py
+++ b/pyspark_datasources/opensky.py
@@ -4,47 +4,12 @@ OpenSky Network Data Source for Apache Spark - Academic/Private Use Example
 This module provides a custom Spark data source for streaming real-time aircraft
 tracking data from the OpenSky Network API (https://opensky-network.org/).
 
-Fixes over the original implementation:
+Provides a streaming reader (``spark.readStream``) and a batch reader
+(``spark.read``) over the OpenSky ``/states/all`` endpoint. Authentication uses
+the OAuth2 client-credentials flow and is performed lazily at read time (never
+during query planning), and the HTTP session is fork- and pickle-safe.
 
-1. CRASH WITH client_id/client_secret (the reported bug):
-   The original reader called `_get_access_token()` (a network request) inside
-   `__init__`. Spark instantiates the reader during query planning inside a
-   *forked* `pyspark.daemon` worker. On macOS, `requests` consults the system
-   proxy configuration via the SystemConfiguration framework
-   (`urllib.request.proxy_bypass_macosx_sysconf`), which is not fork-safe and
-   segfaults the worker ("Python worker exited unexpectedly (crashed)").
-   Fix: no network I/O in `__init__` — the OAuth token is fetched lazily on
-   first read, and the HTTP session is created with `trust_env=False` so no
-   fork-unsafe system proxy lookup ever happens (explicit HTTPS_PROXY/HTTP_PROXY
-   environment variables are still honored manually).
-
-2. PICKLE / FORK SAFETY:
-   The reader is pickled between the driver and worker processes. The
-   `requests.Session` (which may hold live SSL sockets) is now excluded from
-   pickling and recreated lazily in each process.
-
-3. TOKEN REFRESH USES THE RETRYING SESSION:
-   The token request now goes through the same retry-enabled session as data
-   requests, and the token is transparently refreshed before expiry.
-
-4. CORRECT FIELD MAPPING:
-   Per the OpenSky API documentation, state[7] is *barometric* altitude,
-   state[13] is *geometric* altitude, state[16] is position_source, and the
-   aircraft `category` is only returned as state[17] when the request is made
-   with `extended=1`. The original mapped state[7]→geo_altitude,
-   state[13]→baro_altitude and state[16]→category. The schema is unchanged, but
-   the values are now correct and `extended=1` is requested.
-
-5. SAFE TIMESTAMP PARSING:
-   `time_position` (state[3]) may be null; the original crashed the whole
-   micro-batch on `datetime.fromtimestamp(None)`. Timestamps are now parsed
-   defensively.
-
-6. BATCH SUPPORT:
-   In addition to `spark.readStream`, `spark.read.format("opensky")` now works
-   and returns one snapshot of the current state vectors.
-
-Usage (unchanged from the original):
+Usage:
 
     df = spark.readStream.format("opensky").load()
 
@@ -55,9 +20,9 @@ Usage (unchanged from the original):
         .load()
 
 Rate Limits & Responsible Usage:
-    - Anonymous access: 100 API calls per day
-    - Authenticated access: 4000 API calls per day (research accounts)
-    - Minimum 5-second interval between requests
+    - Anonymous access: 400 credits/day, 10-second data resolution
+    - Authenticated access: 4000 credits/day, 5-second data resolution
+      (research accounts)
 
 Data Attribution:
     When using this data in research or publications, please cite:
@@ -153,6 +118,24 @@ class RateLimitError(TransientOpenSkyError):
     do not kill the stream."""
 
 
+class EgressBlockedError(ConfigOpenSkyError):
+    """The TCP connection to OpenSky was silently dropped (DNS resolved but no
+    SYN-ACK → ConnectTimeout). That is the signature of an egress/IP block, not
+    a transient blip that will self-heal — so this is a ConfigOpenSkyError and
+    propagates to fail the pipeline update loudly with an actionable message,
+    rather than being swallowed into silent zero rows."""
+
+
+def _egress_blocked_msg(host: str) -> str:
+    """User-facing message for a dropped TCP connect (egress/IP block signature)."""
+    return (
+        f"Cannot reach OpenSky (TCP connect to {host} timed out after 10s). "
+        "DNS resolved but the connection was silently dropped — this is typically "
+        "OpenSky blocking the request, not a Databricks issue. This workspace's "
+        "shared cloud egress IP may be on OpenSky's blocklist."
+    )
+
+
 class OpenSkyClient:
     """Fork- and pickle-safe OpenSky API client with lazy OAuth2 authentication.
 
@@ -161,16 +144,29 @@ class OpenSkyClient:
     read. The live session object is never pickled.
     """
 
-    MIN_REQUEST_INTERVAL = 5.0  # seconds between requests
+    # OpenSky's data resolution (and minimum useful poll interval) is 5s for
+    # authenticated accounts and 10s for anonymous; polling faster just burns
+    # the daily credit budget on duplicate snapshots. Chosen per-client in
+    # __init__ based on whether credentials were supplied.
+    REQUEST_INTERVAL_AUTHENTICATED = 5.0
+    REQUEST_INTERVAL_ANONYMOUS = 10.0
     MAX_RETRIES = 3
     RETRY_BACKOFF = 2
-    RETRY_STATUS_CODES = [429, 500, 502, 503, 504]
+    # 429 is intentionally NOT in this list: the retrying adapter would raise a
+    # RetryError before the response reaches our handler, so 429 is handled
+    # explicitly in fetch_states() (-> RateLimitError, transient) instead.
+    RETRY_STATUS_CODES = [500, 502, 503, 504]
     TOKEN_REFRESH_MARGIN = 60  # refresh this many seconds before expiry
 
     def __init__(self, bbox: BoundingBox, client_id: Optional[str], client_secret: Optional[str]):
         self.bbox = bbox
         self.client_id = client_id
         self.client_secret = client_secret
+        self.min_request_interval = (
+            self.REQUEST_INTERVAL_AUTHENTICATED
+            if (client_id and client_secret)
+            else self.REQUEST_INTERVAL_ANONYMOUS
+        )
         self._session: Optional[requests.Session] = None
         self._access_token: Optional[str] = None
         self._token_expires_at: float = 0.0
@@ -223,9 +219,17 @@ class OpenSkyClient:
         }
         try:
             response = self.session.post(TOKEN_URL, data=data, timeout=10)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
-            # Reaching the token endpoint failed transiently (egress/network).
-            raise TransientOpenSkyError(f"Token request failed transiently: {e}") from e
+        except requests.exceptions.ConnectTimeout as e:
+            # No SYN-ACK within the connect timeout: the TCP connect was silently
+            # dropped — the egress/IP-block signature. Surface it loudly. Must
+            # precede Timeout/ConnectionError (ConnectTimeout subclasses both).
+            raise EgressBlockedError(_egress_blocked_msg("auth.opensky-network.org")) from e
+        except requests.exceptions.Timeout as e:
+            # ReadTimeout: a slow-but-reachable endpoint — transient, let it retry.
+            raise TransientOpenSkyError(f"Token request timed out: {e}") from e
+        except requests.exceptions.ConnectionError as e:
+            # Non-timeout connection failure (refused, DNS, SSL/proxy). Loud.
+            raise EgressBlockedError(_egress_blocked_msg("auth.opensky-network.org")) from e
         except requests.exceptions.RequestException as e:
             # Non-transient HTTP error (e.g. 400/401 for bad client credentials).
             raise ConfigOpenSkyError(f"Failed to get access token: {e}") from e
@@ -234,7 +238,7 @@ class OpenSkyClient:
         if response.status_code in (400, 401, 403):
             raise ConfigOpenSkyError(
                 f"Authentication failed (HTTP {response.status_code}): check "
-                f"client_id/client_secret"
+                "client_id/client_secret"
             )
         try:
             response.raise_for_status()
@@ -255,10 +259,10 @@ class OpenSkyClient:
         self._token_expires_at = now + expires_in - self.TOKEN_REFRESH_MARGIN
 
     def _throttle(self) -> None:
-        """Keep at least MIN_REQUEST_INTERVAL seconds between requests."""
+        """Keep at least ``min_request_interval`` seconds between requests."""
         elapsed = time.time() - self._last_request_time
-        if elapsed < self.MIN_REQUEST_INTERVAL:
-            time.sleep(self.MIN_REQUEST_INTERVAL - elapsed)
+        if elapsed < self.min_request_interval:
+            time.sleep(self.min_request_interval - elapsed)
         self._last_request_time = time.time()
 
     def fetch_states(self) -> Dict[str, Any]:
@@ -296,17 +300,39 @@ class OpenSkyClient:
                     "Authentication failed (HTTP 401) after token refresh: "
                     "check client_id/client_secret"
                 )
+            if 400 <= response.status_code < 500 and response.status_code != 429:
+                # Any other 4xx (e.g. 403 forbidden region/disabled account, 400
+                # bad request) is deterministic: it will not self-heal, so fail
+                # loudly instead of swallowing it into silent zero rows. (429 is
+                # handled by the retrying adapter / RateLimitError above; 401 is
+                # handled just above.)
+                raise ConfigOpenSkyError(
+                    f"OpenSky request rejected (HTTP {response.status_code}): "
+                    f"{response.reason}"
+                )
             response.raise_for_status()
             return response.json()
+        except requests.exceptions.ConnectTimeout as e:
+            # No SYN-ACK within the connect timeout: the data host silently
+            # dropped the TCP connect — the egress/IP-block signature. Fail
+            # loudly instead of silent zero rows. Must precede the Timeout and
+            # ConnectionError clauses: requests.ConnectTimeout is a subclass of
+            # BOTH Timeout and ConnectionError, and only a *connect* timeout is
+            # the block signature (a read timeout is a slow-but-reachable host).
+            raise EgressBlockedError(_egress_blocked_msg("opensky-network.org")) from e
         except requests.exceptions.Timeout as e:
+            # ReadTimeout: the host answered the connect but was slow to respond.
+            # Transient — let the stream retry on the next trigger.
             raise TransientOpenSkyError("API request timed out") from e
         except requests.exceptions.ConnectionError as e:
-            # Includes egress blocks (dropped SYN → ConnectTimeout): self-heals.
-            raise TransientOpenSkyError("Connection error occurred") from e
+            # A non-timeout connection failure (connection refused, DNS failure,
+            # SSL/proxy error). Deterministic enough that swallowing it into
+            # silent zero rows is wrong: fail loudly.
+            raise EgressBlockedError(_egress_blocked_msg("opensky-network.org")) from e
         except requests.exceptions.RequestException as e:
-            # Retries on 5xx/429 are exhausted here (RetryError) or a 4xx slipped
-            # through: treat as transient so a flaky endpoint doesn't kill the
-            # stream. Deterministic auth (401) is already raised above.
+            # Retries on 5xx/429 are exhausted here (RetryError) or another
+            # transient HTTP fault: treat as transient so a flaky endpoint
+            # doesn't kill the stream. Deterministic 4xx/auth are raised above.
             raise TransientOpenSkyError(f"API request failed: {e}") from e
 
 
@@ -398,13 +424,14 @@ class OpenSkyStreamReader(SimpleDataSourceStreamReader):
         """Read the current state vectors and advance the offset.
 
         Error policy (see the exception taxonomy in this module):
-          * TransientOpenSkyError (timeouts, connection/egress errors, 429) is
-            swallowed: we log a warning and return the offset unchanged so no
-            micro-batch is triggered, and the stream auto-recovers once the
-            upstream is reachable again.
+          * TransientOpenSkyError (request timeouts, 429) is swallowed: we log a
+            warning and return the offset unchanged so no micro-batch is
+            triggered, and the stream auto-recovers once the upstream is
+            reachable again.
           * Everything else — ConfigOpenSkyError (bad creds, malformed token),
-            and any unexpected programming error (parse bugs, etc.) — is allowed
-            to propagate. That fails the Structured Streaming micro-batch (and
+            EgressBlockedError (dropped TCP connect → IP/egress block), and any
+            unexpected programming error (parse bugs, etc.) — is allowed to
+            propagate. That fails the Structured Streaming micro-batch (and
             surfaces as a StreamingQueryException / a failed pipeline update)
             instead of silently emitting zero rows.
 
@@ -424,7 +451,12 @@ class OpenSkyStreamReader(SimpleDataSourceStreamReader):
             return ([], start)
 
     def readBetweenOffsets(self, start: Dict[str, int], end: Dict[str, int]) -> Iterator[Tuple]:
-        # The API cannot replay past data; re-fetch the latest snapshot.
+        # KNOWN LIMITATION: the OpenSky API only serves the *current* snapshot and
+        # cannot replay a historical offset range, so exact-once replay on restart
+        # is not possible. `end` is ignored and we re-fetch the latest snapshot;
+        # recovery therefore reprocesses whatever is current, not the original
+        # batch. Acceptable for a live-telemetry source where staleness, not
+        # exactness, is what matters.
         data, _ = self.read(start)
         return iter(data)
 
@@ -482,7 +514,7 @@ class OpenSkyDataSource(DataSource):
     https://opensky-network.org" and the OpenSky IPSN 2014 paper.
     """
 
-    def __init__(self, options: Dict[str, str] = None):
+    def __init__(self, options: Optional[Dict[str, str]] = None):
         super().__init__(options or {})
         self.options = options or {}
 

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,10 +1,24 @@
 import pytest
 import tempfile
 import os
+from unittest import mock
+
 import pyarrow as pa
+import requests
+from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.exceptions import MaxRetryError, ReadTimeoutError
 
 from pyspark.sql import SparkSession
 from pyspark_datasources import *
+from pyspark_datasources.opensky import (
+    ConfigOpenSkyError,
+    EgressBlockedError,
+    OpenSkyClient,
+    RateLimitError,
+    Region,
+    TransientOpenSkyError,
+    parse_response,
+)
 
 
 @pytest.fixture
@@ -61,6 +75,10 @@ def test_kaggle_datasource(spark):
     assert len(df.columns) == 12
 
 
+@pytest.mark.skipif(
+    not os.environ.get("OPENSKY_LIVE_TEST"),
+    reason="hits the live OpenSky API; set OPENSKY_LIVE_TEST=1 to run",
+)
 def test_opensky_datasource_stream(spark):
     spark.dataSource.register(OpenSkyDataSource)
     (
@@ -77,6 +95,86 @@ def test_opensky_datasource_stream(spark):
     result.show()
     assert len(result.columns) == 18  # Check schema has expected number of fields
     assert result.count() > 0  # Verify we got some data
+
+
+# --- Offline OpenSky tests (no network) -------------------------------------
+# These cover the OpenSkyClient error taxonomy directly, without Spark workers
+# or the live API, so they run in CI on every Python version. Anonymous client
+# => _ensure_token() is a no-op (no token request); the mock session replaces
+# the only network call in fetch_states().
+
+
+def _anon_client_with_session(mock_session):
+    """An anonymous OpenSkyClient whose lazy session is the given mock."""
+    client = OpenSkyClient(Region.EUROPE.value, client_id=None, client_secret=None)
+    client._session = mock_session  # property returns it since it's not None
+    return client
+
+
+def _read_timeout_connection_error():
+    """The exact shape requests raises when urllib3 read retries are exhausted:
+    ConnectionError(MaxRetryError(reason=ReadTimeoutError))."""
+    pool = HTTPSConnectionPool("opensky-network.org")
+    url = "https://opensky-network.org/api/states/all"
+    reason = ReadTimeoutError(pool, url, "read timed out")
+    return requests.exceptions.ConnectionError(MaxRetryError(pool, url, reason=reason))
+
+
+def test_fetch_states_read_timeout_is_transient():
+    # Regression test for P1 #1: an exhausted read retry arrives as a
+    # ConnectionError wrapping a ReadTimeoutError. It must be TRANSIENT (stream
+    # self-heals), not EgressBlockedError (which would kill the stream).
+    session = mock.Mock()
+    session.get.side_effect = _read_timeout_connection_error()
+    client = _anon_client_with_session(session)
+    # TransientOpenSkyError is disjoint from EgressBlockedError (a
+    # ConfigOpenSkyError), so this also proves it is NOT a fatal egress block.
+    with pytest.raises(TransientOpenSkyError):
+        client.fetch_states()
+
+
+def test_fetch_states_connect_timeout_is_egress():
+    # A dropped TCP connect (no SYN-ACK) is the egress/IP-block signature: loud.
+    session = mock.Mock()
+    session.get.side_effect = requests.exceptions.ConnectTimeout("connect timed out")
+    client = _anon_client_with_session(session)
+    with pytest.raises(EgressBlockedError):
+        client.fetch_states()
+
+
+def test_fetch_states_429_is_rate_limit():
+    session = mock.Mock()
+    session.get.return_value = mock.Mock(status_code=429)
+    client = _anon_client_with_session(session)
+    with pytest.raises(RateLimitError):
+        client.fetch_states()
+
+
+def test_fetch_states_401_is_config_error():
+    # 401 with no token to refresh (anonymous) is a deterministic config fault.
+    session = mock.Mock()
+    session.get.return_value = mock.Mock(status_code=401)
+    client = _anon_client_with_session(session)
+    with pytest.raises(ConfigOpenSkyError):
+        client.fetch_states()
+
+
+def test_parse_response_field_mapping():
+    # Guards the (schema-silent) field mapping: geo_altitude<-state[13],
+    # baro_altitude<-state[7], category<-state[17] (extended=1 layout).
+    state = [
+        "abc123", "TEST    ", "Testland", 1700000000, 1700000001,
+        8.5, 50.0, 1000.0, False, 200.0, 180.0, 0.0, None, 1050.0,
+        "1000", False, 0, 2,
+    ]  # indices 0..17; [7]=baro=1000, [13]=geo=1050, [17]=category=2
+    rows = parse_response({"time": 1700000002, "states": [state]})
+    assert len(rows) == 1
+    row = rows[0]
+    # parse_state tuple positions: 8=geo_altitude, 14=baro_altitude, 17=category
+    assert row[8] == 1050.0  # geo_altitude
+    assert row[14] == 1000.0  # baro_altitude
+    assert row[8] > row[14]  # geo > baro, as OpenSky docs specify
+    assert row[17] == 2  # category from state[17]
 
 
 def test_salesforce_datasource_registration(spark):


### PR DESCRIPTION
## Summary
The stock `OpenSkyDataSource` breaks the moment `client_id`/`client_secret` are supplied: it makes a network call (`_get_access_token()`) inside the stream reader's `__init__`, which Spark runs at query-planning time — segfaulting the forked worker on macOS and timing out at plan time on Databricks. Anonymous access only worked because it happened to skip that call.

This PR makes authentication safe (no network I/O during planning, fork-/pickle-safe session) **and** gives the source an explicit error taxonomy so misconfigurations and egress blocks fail loudly instead of silently returning empty batches.

## What changed
- **No network I/O in `__init__`** — OAuth (client-credentials flow) is now lazy, fetched at read time and cached with a refresh margin. *(the crash fix)*
- **Fork-/pickle-safe session** — `requests.Session(trust_env=False)`, excluded from pickling and rebuilt lazily per process.
- **Explicit error taxonomy** — `OpenSkyAPIError` splits into `TransientOpenSkyError` (timeouts / read-timeouts / 429 → logged and skipped so the stream self-heals) and `ConfigOpenSkyError` (bad credentials, malformed token, HTTP 401/4xx, and `EgressBlockedError` for a dropped TCP connect → **propagate and fail the query** instead of returning 0 rows silently).
  - `EgressBlockedError` carries an actionable message ("Cannot reach OpenSky … egress IP may be on OpenSky's blocklist") — the common case where a shared cloud egress IP is blocked by OpenSky.
  - A dropped-SYN connect timeout is classified by catching `requests.ConnectTimeout` **before** `Timeout` (it subclasses both), so an egress block is never mistaken for a transient read timeout.
- **Correct field mapping** — `baro_altitude=state[7]`, `geo_altitude=state[13]` (were swapped); `category=state[17]` with `extended=1` (was reading `position_source` at `state[16]`); null-safe `time_position` parsing.
- **Batch reader** — `spark.read.format("opensky")` now returns a current-snapshot DataFrame in addition to `spark.readStream`.
- **Mode-aware polling** — 5s interval authenticated, 10s anonymous (matches OpenSky's data resolution; polling faster just burns the daily credit budget).

## ⚠️ Behavior changes vs the stock source (schema is unchanged, so these are otherwise silent)
1. **`geo_altitude` / `baro_altitude` values are swapped.** Same column names and types, but the stock source mapped them backwards (`state[7]`↔`state[13]`). The new values are correct per the OpenSky docs, but any stored data or downstream logic keyed on these two columns changes meaning.
2. **`category` is now the real aircraft category** (`state[17]`, `extended=1`), not the `position_source` integer the stock source returned at `state[16]`.
3. **Some failures now fail the query instead of returning 0 rows.** Bad credentials, HTTP 4xx, and egress/IP blocks previously produced silent empty batches; they now raise. Transient faults (timeouts, 429) are still logged and skipped so the stream self-heals.

### Known limitation
`readBetweenOffsets` cannot replay a historical range — the OpenSky API only serves the current snapshot — so exact-once replay on restart isn't possible; recovery reprocesses the current snapshot. Documented inline. Fine for a live-telemetry source.

## Testing
Validated on serverless Spark Declarative Pipelines in both modes, on an open-egress workspace and an egress-blocked workspace:

| Scenario | Result |
|---|---|
| Anonymous, open egress | ✅ COMPLETED, **4,511 rows** |
| client_id/secret, open egress | ✅ COMPLETED, **4,499 rows** — the regression this PR repairs |
| Egress blocked (shared IP on OpenSky's blocklist) | ✅ update **FAILS** with a clear `EgressBlockedError` in the event log (previously: silent 0 rows) |

Authenticated and anonymous runs both show `geo_altitude > baro_altitude` (~97% of rows) and populated `category`, confirming the corrected field mapping and `extended=1`.

This pull request and its description were written by Isaac.
