### PR TITLE
fix: minimal example to get started by adding classmethod annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ from pyspark.sql.datasource import DataSource, DataSourceReader
 from pyspark.sql.types import StructType, StructField, StringType, IntegerType
 
 class MyCustomDataSource(DataSource):
+    @classmethod
     def name(self):
         return "mycustom"
 


### PR DESCRIPTION
## Summary
- Update README.md to update minimal example, was missing classmethod annotation on name method. Also found that in [docs](https://spark.apache.org/docs/latest/api/python/tutorial/sql/python_data_source.html)