### PR TITLE
fix: SharePoint f-string backslash SyntaxError breaks CI on Python < 3.12

### DIFF
--- a/pyspark_datasources/sharepoint.py
+++ b/pyspark_datasources/sharepoint.py
@@ -337,8 +337,10 @@ class SharepointStreamWriter(DataSourceStreamWriter):
                 *self.resource.validate_required_options(),
             ]
         ):
+            base_options = "\n\t".join(f"{datasource}.{ro}" for ro in self._required_options)
+            resource_options = "\n\t".join(self.resource.required_options())
             raise ValueError(
-                f"Sharepoint options \n\t{'\n\t'.join([f'{datasource}.{ro}' for ro in self._required_options])}\nand resource specific options\n\t{'\n\t'.join(self.resource.required_options())}\nare required. "
+                f"Sharepoint options \n\t{base_options}\nand resource specific options\n\t{resource_options}\nare required. "
                 "Set them using .option() / .options() method in your streaming query."
             )
 
@@ -414,7 +416,8 @@ class SharepointStreamWriter(DataSourceStreamWriter):
             flush_buffer()
 
         if total_records_failed:
-            msg = f"Failed to write {len(total_records_failed)} records to Sharepoint (batch {batch_id}):\n\t{'\n\t'.join([str(f) for f in total_records_failed])}"
+            failed_details = "\n\t".join(str(f) for f in total_records_failed)
+            msg = f"Failed to write {len(total_records_failed)} records to Sharepoint (batch {batch_id}):\n\t{failed_details}"
             if self.fail_fast:
                 raise Exception(msg)
             else:


### PR DESCRIPTION
## Problem
`pyspark_datasources/sharepoint.py` (introduced in #60) used `'\n\t'.join(...)` **inside** f-string replacement fields (lines 341 and 419). Backslashes inside f-string expressions are only legal on Python 3.12+ (PEP 701), so on 3.9/3.10/3.11 the module raises:

```
SyntaxError: f-string expression part cannot include a backslash
```

Because importing the module fails, pytest **collection** of the whole suite aborts (`test_data_sources.py`, `test_google_sheets.py`, `test_robinhood.py` → "3 errors during collection"), turning CI red on every Python version except 3.12.

## Fix
Hoist the newline-joined strings into locals so no backslash sits inside the f-string braces. No behavior change.

## Verification
- `python -c "import ast; ast.parse(open(...))"` on Python 3.10: fails before, passes after.
- pytest collection: `3 errors during collection` → `89 tests collected`.
- Full suite on Python 3.10 + Java 17: **84 passed, 2 skipped** (the 3 remaining failures are live-network tests — github/kaggle/opensky — that require egress unavailable in the sandbox; they pass in CI).

This pull request and its description were written by Isaac.